### PR TITLE
refactor(loadModule): remove redundant await

### DIFF
--- a/packages/holocron/src/loadModule.node.js
+++ b/packages/holocron/src/loadModule.node.js
@@ -76,7 +76,7 @@ export default async function loadModule(
     let nodeModule;
 
     try {
-      await checkStatus(moduleResponse);
+      checkStatus(moduleResponse);
       const moduleString = await moduleResponse.text();
       if (process.env.NODE_ENV === 'production') {
         const actualSRI = ssri.fromData(


### PR DESCRIPTION
# Description

I think there's a redundant await since the `checkStatus` function is synchronous.

https://github.com/americanexpress/holocron/blob/master/packages/holocron/src/loadModule.node.js#L53