### PR TITLE
fix(readme): fix import statement for module route

### DIFF
--- a/packages/holocron-module-route/README.md
+++ b/packages/holocron-module-route/README.md
@@ -59,7 +59,7 @@ redux store and returns a single route or an array of routes.
 
 ``` javascript
 import React from 'react';
-import { ModuleRoute } from 'holocron-module-route';
+import ModuleRoute from 'holocron-module-route';
 
 export default function getChildRoutes(store) {
   return (


### PR DESCRIPTION
Currently, the documented import statement will lead to an undefined import and warning/errors on build/runtime