### PR TITLE
feat(loadModule): rename "key" to "clientCacheRevision"

### DIFF
--- a/packages/holocron/src/loadModule.web.js
+++ b/packages/holocron/src/loadModule.web.js
@@ -48,8 +48,8 @@ export default function loadModule(moduleName, moduleData) {
     if (isProduction) {
       script.integrity = integrity;
     }
-    const key = getModuleMap().get('key');
-    script.src = isProduction && key ? `${url}?key=${key}` : url;
+    const clientCacheRevision = getModuleMap().get('clientCacheRevision', getModuleMap().get('key'));
+    script.src = isProduction && clientCacheRevision ? `${url}?clientCacheRevision=${clientCacheRevision}` : url;
     const timeout = setTimeout(onScriptComplete, 120000);
     script.addEventListener('error', (event) => {
       clearTimeout(timeout);


### PR DESCRIPTION
The name `key` was terrible. Fixing that with a more descriptive name. Keeping the functionality to use `key` as to be non-breaking.