### PR TITLE
chore(workflows): update stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,10 +13,11 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove no-issue-activity label or comment or this will be closed in 5 days.'
-        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove no-pr-activity label or comment or this will be closed in 5 days.'
-        stale-issue-label: 'no-issue-activity'
-        exempt-issue-label: 'enhancement'
-        stale-pr-label: 'no-pr-activity'
+        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.'
+        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity.'
+        stale-issue-label: 'stale-issue'
+        exempt-issue-labels: 'enhancement,documentation,good-first-issue,question'
+        stale-pr-label: 'stale-pr'
+        exempt-pr-labels: 'work-in-progress'
         days-before-stale: 30
-        days-before-close: 5
+        days-before-close: -1


### PR DESCRIPTION
This PR does the following:

- Updates action to v3
- Adds `days-before-close` to `-1` so it doesn't close anything (https://github.com/actions/stale/blob/master/action.yml#L16)
- Adds `exempt-issue-labels` and `exempt-pr-labels`