### PR TITLE
fix(holocron/load): prevent rebuilding without reducer

### DIFF
--- a/packages/holocron/__tests__/ducks/load.spec.js
+++ b/packages/holocron/__tests__/ducks/load.spec.js
@@ -207,10 +207,11 @@ describe('loadModule', () => {
       },
     });
     const rebuildReducer = jest.fn();
-    const modules = iMap({ 'my-module': 'Preloaded MockModule' });
-    await expect(thunk(dispatch, getState, { rebuildReducer, modules })).resolves.toBe('Preloaded MockModule');
+    const Module = { holocron: { name: 'my-module', reducer } };
+    const modules = iMap({ 'my-module': Module });
+    await expect(thunk(dispatch, getState, { rebuildReducer, modules })).resolves.toBe(Module);
     expect(dispatch).toHaveBeenCalledWith({ type: MODULE_LOADED, moduleName: 'my-module' });
-    expect(rebuildReducer).toHaveBeenCalled();
+    expect(rebuildReducer).not.toHaveBeenCalled();
   });
 
   it('should reject if it is not preloaded on the server', async () => {
@@ -275,6 +276,31 @@ describe('loadModule', () => {
     expect(dispatch).toHaveBeenCalledWith({ type: MODULE_REDUCER_ADDED });
     expect(dispatch).toHaveBeenCalledWith({ type: MODULE_LOADED, moduleName: 'my-module' });
     expect(rebuildReducer).toHaveBeenCalled();
+  });
+
+  it('should not rebuild the store when a module is loaded successfully does not have a reducer', async () => {
+    const Module = 'Module';
+    require('../../src/loadModule.web').default.mockImplementationOnce(() => Promise.resolve(Module));
+    getModuleMap.mockReturnValue(
+      fromJS({ modules: { 'my-module': {} } })
+    );
+
+    const thunk = loadModule('my-module');
+    const dispatch = jest.fn((x) => x);
+    const getState = () => fromJS({
+      holocron: {
+        loaded: iSet(),
+        failed: {},
+        loading: {},
+        moduleVersions: { 'my-module': '1.2.3' },
+      },
+    });
+    const rebuildReducer = jest.fn();
+    await expect(thunk(dispatch, getState, { rebuildReducer })).resolves.toBe(Module);
+    expect(dispatch).toHaveBeenCalledWith({ type: MODULE_LOADED, moduleName: 'my-module' });
+    expect(dispatch).not.toHaveBeenCalledWith({ type: REGISTER_MODULE_REDUCER, moduleName: 'my-module' });
+    expect(dispatch).not.toHaveBeenCalledWith({ type: MODULE_REDUCER_ADDED });
+    expect(rebuildReducer).not.toHaveBeenCalled();
   });
 
   it('should load a module if the loading promise is falsy', async () => {

--- a/packages/holocron/__tests__/ducks/load.spec.js
+++ b/packages/holocron/__tests__/ducks/load.spec.js
@@ -278,7 +278,7 @@ describe('loadModule', () => {
     expect(rebuildReducer).toHaveBeenCalled();
   });
 
-  it('should not rebuild the store when a module is loaded successfully does not have a reducer', async () => {
+  it('should not rebuild the store when a module without a reducer is loaded successfully', async () => {
     const Module = 'Module';
     require('../../src/loadModule.web').default.mockImplementationOnce(() => Promise.resolve(Module));
     getModuleMap.mockReturnValue(

--- a/packages/holocron/src/ducks/load.js
+++ b/packages/holocron/src/ducks/load.js
@@ -151,9 +151,11 @@ export function loadModule(moduleName) {
     return loadPromise
       .then(
         (module) => {
-          if (module[REDUCER_KEY]) dispatch(registerModuleReducer(moduleName));
-          rebuildReducer();
-          dispatch({ type: MODULE_REDUCER_ADDED });
+          if (module[REDUCER_KEY]) {
+            dispatch(registerModuleReducer(moduleName));
+            rebuildReducer();
+            dispatch({ type: MODULE_REDUCER_ADDED });
+          }
           dispatch(moduleLoaded(moduleName));
           return module;
         },


### PR DESCRIPTION
This bugfix prevents rebuilding of Holocron store if a reducer is not supplied during module load.