### PR TITLE
docs: Update holocron usage#1

### DIFF
--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -141,11 +141,6 @@ HelloWorld.holocron = {
   // options,
 };
 
-if (!global.BROWSER) {
-  // eslint-disable-next-line global-require
-  HelloWorld.appConfig = require('../appConfig').default;
-}
-
 export default HelloWorld;
 ```
 

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -103,29 +103,47 @@ The optional `holocron` object set to the parent React Component inside a Holocr
 ```jsx
 import React from 'react';
 import PropTypes from 'prop-types';
-import { reducer, fetchData } from '../duck';
+import { fromJS } from 'immutable';
 
-const HelloWorld = ({ moduleState: { myData } }) => (
-  <h1>
-Hello,
-    {myData.name}
-  </h1>
-);
-HelloWorld.propTypes = {
-  moduleState: PropTypes.shape({
-    myData: PropTypes.string,
-  }).isRequired,
+const HelloWorld = ({ moduleState: { name }, moduleLoadStatus }) => {
+  if (moduleLoadStatus === 'loading') return <h1>Loading...</h1>;
+  if (moduleLoadStatus === 'error') return <h1>Error!</h1>;
+  return <h1>Hello, {name}!</h1>;
 };
 
-const loadModuleData = ({ store: { dispatch }, ownProps }) => dispatch(fetchData(ownProps.input));
-const shouldModuleReload = (oldProps, newProps) => oldProps.input !== newProps.input;
+HelloWorld.propTypes = {
+  moduleState: PropTypes.shape({
+    name: PropTypes.string,
+  }).isRequired,
+  moduleLoadStatus: PropTypes.oneOf(['loading', 'loaded', 'error']),
+};
+
+const loadModuleData = ({ store: { dispatch } }) => dispatch({ type: 'SET_NAME', name: 'World' });
+
+const shouldModuleReload = (oldProps, newProps) => oldProps.moduleState?.name !== newProps.moduleState?.name;
+
+// This reducer is supplying 'moduleState' in our component
+// Note: reducers use immutable.js
+const reducer = (state = fromJS({}), action) => {
+  switch (action.type) {
+    case 'SET_NAME': {
+      return state.set('name', action.name);
+    }
+    default: return state;
+  }
+};
 
 HelloWorld.holocron = {
-  name: 'hello-world',
+  name: 'holocron-hello-world',
   reducer,
   loadModuleData,
   shouldModuleReload,
-  options,
+  // options,
+};
+
+if (!global.BROWSER) {
+  // eslint-disable-next-line global-require
+  HelloWorld.appConfig = require('../appConfig').default;
 }
 
 export default HelloWorld;


### PR DESCRIPTION
This is a simple example of a basic 'hello world' holocron module.

## Description
This is an attempt to help the readability of the holocron usage #1 documentation. I debated adding childroutes so the code could work out-of-the-box for beginners/first-time users.

## Motivation and Context
When I was reading the holocron documentation for the first time, I was confused by the different '.inputs', the declared shape of the 'moduleState' vs the usage of the moduleState in the function, and an example of a reducer.

## How Has This Been Tested?
This was tested locally using holocron 1.1.0, and one-apps' npx module generator code for a 'root module' with some modifications: childRoutes removed, prop-types added, and immutable added, with a custom reducer, shouldModuleReload, and loadModuleData.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
This change will hopefully allow beginners and first-time users that are reading the documentation to have a more clear understanding of the basic parts of holocron in a small example.
