### PR TITLE
fix(ModuleName): use correct default for old bundler

### DIFF
--- a/packages/holocron-module-register-webpack-plugin/HolocronModuleRegisterPlugin.js
+++ b/packages/holocron-module-register-webpack-plugin/HolocronModuleRegisterPlugin.js
@@ -15,7 +15,7 @@
 const { ConcatSource } = require('webpack-sources');
 const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
 
-function HolocronModuleRegisterPlugin(moduleName, holocronModuleName = 'holocronModuleName') {
+function HolocronModuleRegisterPlugin(moduleName, holocronModuleName = 'holocronModule') {
   this.moduleName = moduleName;
   this.holocronModuleName = holocronModuleName;
   this.options = {};

--- a/packages/holocron-module-register-webpack-plugin/__tests__/HolocronModuleRegisterPlugin.spec.js
+++ b/packages/holocron-module-register-webpack-plugin/__tests__/HolocronModuleRegisterPlugin.spec.js
@@ -52,7 +52,7 @@ describe('HolocronModuleRegisterPlugin', () => {
       const fileContents = fs.readFileSync(path.join(buildPath, outputFileName)).toString();
       expect(fileContents.startsWith('(function() {')).toBe(true);
       expect(fileContents).toContain('const SomeModule = () => null;');
-      expect(fileContents.endsWith('Holocron.registerModule("some-module", holocronModuleName);})();')).toBe(true);
+      expect(fileContents.endsWith('Holocron.registerModule("some-module", holocronModule);})();')).toBe(true);
       done();
     });
   });
@@ -74,7 +74,7 @@ describe('HolocronModuleRegisterPlugin', () => {
       if (stats.hasErrors()) done.fail(stats.toJson().errors);
       const fileContents = fs.readFileSync(path.join(buildPath, outputFileName)).toString();
       expect(fileContents).toContain('()=>null');
-      expect(fileContents.endsWith('Holocron.registerModule("some-module",holocronModuleName);')).toBe(true);
+      expect(fileContents.endsWith('Holocron.registerModule("some-module",holocronModule);')).toBe(true);
       done();
     });
   });
@@ -98,7 +98,7 @@ describe('HolocronModuleRegisterPlugin', () => {
       const fileContents = fs.readFileSync(path.join(buildPath, outputFileName)).toString();
       expect(fileContents.startsWith('(function() {')).toBe(true);
       expect(fileContents).toContain('const ModuleWithAsyncImport = () =>');
-      expect(fileContents.endsWith('Holocron.registerModule("some-module", holocronModuleName);})();')).toBe(true);
+      expect(fileContents.endsWith('Holocron.registerModule("some-module", holocronModule);})();')).toBe(true);
       const asyncChunkContents = fs.readFileSync(path.join(buildPath, `async-import.${outputFileName}`)).toString();
       expect(asyncChunkContents).toContain('() => \'Hello, world\'');
       expect(asyncChunkContents).not.toContain('Holocron.registerModule("some-module"');


### PR DESCRIPTION
The correct name of holocron modules in old bundlers is `holocronModule` not `holocronModuleName`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
<!--- Please describe how your changes impacts developers using Holocron. -->
