### PR TITLE
feat(forceLoadModule): expose loadModule function for browsers

### DIFF
--- a/packages/holocron/__tests__/__snapshots__/index.spec.js.snap
+++ b/packages/holocron/__tests__/__snapshots__/index.spec.js.snap
@@ -6,6 +6,7 @@ Object {
   "composeModules": [Function],
   "createHolocronStore": [Function],
   "failedToLoad": [Function],
+  "forceLoadModule": [Function],
   "getLoadError": [Function],
   "getLoadingPromise": [Function],
   "getModule": [Function],

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -646,6 +646,7 @@ import { forceLoadModule, getModuleMap } from 'holocron';
 
 export const MyComponent = (props) => {
   const [LoadedModule, setLoadedModule] = React.useState(null);
+
   React.useEffect(async () => {
     const moduleData = getModuleMap().getIn(['modules', moduleName]);
     const MyModule = await forceLoadModule('my-module', moduleData);

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -31,6 +31,8 @@ available on the server. We have organized them as such.
   - [`getLoadError`](#getLoadError)
   - [`isLoading`](#isloading)
   - [`getLoadingPromise`](#getloadingpromise)
+- [Advanced Functions](#advanced-functions)
+  - [`forceLoadModule`](#forceloadmodule)
 
 ### App-level Functions
 
@@ -609,6 +611,52 @@ const getModulesToUpdate = (
   !areModuleEntriesEqual(curr[moduleName], next[moduleName])
         || someOtherLogic(moduleName))
 );
+```
+
+<!--ONE-DOCS-ID end-->
+
+### Advanced Functions
+
+These functions are exposed to allow more advanced uses of Holocron.
+
+<!--ONE-DOCS-ID id="forceLoadModule" start-->
+
+#### `forceLoadModule`
+
+Re-loads a modules source code, re-injects it into the page, and return its top level export.
+
+This function can allow a browser to re-fetch a module directly, without requiring a page load.
+
+Note: you should not need to call this function yourself to load modules into the browser under most use cases. Instead, use the duck `loadModule`.
+
+##### Arguments
+
+| name | type | required | value |
+|---|---|---|---|
+| `moduleName` | `string` | `true` | The name of the module to try to reload |
+| `moduleData` | `object` | `true` | The moduleData object that stores the url, and integrity for all modules |
+
+
+##### Usage
+
+Directly load a fresh instance of a module. Note: Under normal use cases, use RenderModule to render a module in JSX.
+
+```js
+import { forceLoadModule, getModuleMap } from 'holocron';
+
+export const MyComponent = (props) => {
+  const [LoadedModule, setLoadedModule] = React.useState(null);
+  React.useEffect(async () => {
+    const moduleData = getModuleMap().getIn(['modules', moduleName]);
+    const MyModule = await forceLoadModule('my-module', moduleData);
+    setLoadedModule(MyModule);
+  })
+  
+  return LoadedModule || (
+    <LoadedModule {...props} />
+  );
+}
+
 ```
 
 <!--ONE-DOCS-ID end-->

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -633,8 +633,8 @@ This function can allow a browser to re-fetch a module directly, without requiri
 
 | name | type | required | value |
 |---|---|---|---|
-| `moduleName` | `string` | `true` | The name of the module to try to reload |
-| `moduleData` | `object` | `true` | The moduleData object that stores the url, and integrity for all modules |
+| `moduleName` | `String` | `true` | The name of the module to try to reload |
+| `moduleData` | `Object` | `true` | The URLs and integrity values for all the module |
 
 
 ##### Usage

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -623,9 +623,9 @@ These functions are exposed to allow more advanced uses of Holocron.
 
 #### `forceLoadModule`
 
-Re-loads a modules source code, re-injects it into the page, and return its top level export.
+Reloads a modules source code, reinjects it into the page, and return its top level export.
 
-This function can allow a browser to re-fetch a module directly, without requiring a page load.
+This function can allow a browser to refetch a module directly, without requiring a page load.
 
 > Note: you should not need to call this function yourself to load modules into the browser under most use cases. Instead, use the duck `loadModule`.
 

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -648,7 +648,7 @@ export const MyComponent = (props) => {
   const [LoadedModule, setLoadedModule] = React.useState(null);
 
   React.useEffect(async () => {
-    const moduleData = getModuleMap().getIn(['modules', moduleName]);
+    const moduleData = getModuleMap().getIn(['modules', 'my-module']);
     const MyModule = await forceLoadModule('my-module', moduleData);
     setLoadedModule(MyModule);
   })

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -627,7 +627,7 @@ Re-loads a modules source code, re-injects it into the page, and return its top 
 
 This function can allow a browser to re-fetch a module directly, without requiring a page load.
 
-Note: you should not need to call this function yourself to load modules into the browser under most use cases. Instead, use the duck `loadModule`.
+> Note: you should not need to call this function yourself to load modules into the browser under most use cases. Instead, use the duck `loadModule`.
 
 ##### Arguments
 

--- a/packages/holocron/src/index.js
+++ b/packages/holocron/src/index.js
@@ -31,6 +31,7 @@ import {
 import { composeModules } from './ducks/compose';
 import RenderModule from './RenderModule';
 import holocronModule from './publicHolocronModule';
+import forceLoadModule from './loadModule.web';
 
 // Public API
 export {
@@ -49,4 +50,5 @@ export {
   getLoadingPromise,
   RenderModule,
   holocronModule,
+  forceLoadModule,
 };


### PR DESCRIPTION
This function facilitates re-loading a module directly in the browser
and exposing it is a pre-cursor to enabling single module reloading

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
This advanced feature will facilitate hot module reload.