### PR TITLE
feat(holocronModuleWrapper): make moduleState opt out

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "jest": "^25.1.0",
     "lerna": "^3.22.1",
     "lockfile-lint": "^4.1.0",
+    "prettier": "^2.8.4",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.12.0",

--- a/packages/holocron/__tests__/__snapshots__/holocronModule.spec.jsx.snap
+++ b/packages/holocron/__tests__/__snapshots__/holocronModule.spec.jsx.snap
@@ -37,6 +37,13 @@ exports[`holocronModule should gracefully handle module state missing from store
 </div>
 `;
 
+exports[`holocronModule should not pass the moduleState to the module if options.provideModuleState is passed as false 1`] = `
+<div>
+  |
+  undefined
+</div>
+`;
+
 exports[`holocronModule should pass mergeProps to connect if it is specified 1`] = `
 <div>
   3
@@ -44,6 +51,14 @@ exports[`holocronModule should pass mergeProps to connect if it is specified 1`]
   4
    = 
   12
+</div>
+`;
+
+exports[`holocronModule should pass the moduleState to the module by default, if a reducer and name are specified 1`] = `
+<div>
+  {"mockKey":"mockValue"}
+  |
+  object
 </div>
 `;
 

--- a/packages/holocron/__tests__/__snapshots__/holocronModule.spec.jsx.snap
+++ b/packages/holocron/__tests__/__snapshots__/holocronModule.spec.jsx.snap
@@ -37,13 +37,6 @@ exports[`holocronModule should gracefully handle module state missing from store
 </div>
 `;
 
-exports[`holocronModule should not pass the moduleState to the module if options.provideModuleState is passed as false 1`] = `
-<div>
-  |
-  undefined
-</div>
-`;
-
 exports[`holocronModule should pass mergeProps to connect if it is specified 1`] = `
 <div>
   3
@@ -51,22 +44,6 @@ exports[`holocronModule should pass mergeProps to connect if it is specified 1`]
   4
    = 
   12
-</div>
-`;
-
-exports[`holocronModule should pass the moduleState to the module by default, if a reducer and name are specified 1`] = `
-<div>
-  {"mockKey":"mockValue"}
-  |
-  object
-</div>
-`;
-
-exports[`holocronModule should pass the moduleState to the module if options is passed without the \`provideModuleState\` key for backwards compatibility 1`] = `
-<div>
-  {"mockKey":"mockValue"}
-  |
-  object
 </div>
 `;
 

--- a/packages/holocron/__tests__/__snapshots__/holocronModule.spec.jsx.snap
+++ b/packages/holocron/__tests__/__snapshots__/holocronModule.spec.jsx.snap
@@ -62,6 +62,14 @@ exports[`holocronModule should pass the moduleState to the module by default, if
 </div>
 `;
 
+exports[`holocronModule should pass the moduleState to the module if options is passed without the \`provideModuleState\` key for backwards compatibility 1`] = `
+<div>
+  {"mockKey":"mockValue"}
+  |
+  object
+</div>
+`;
+
 exports[`holocronModule should provide the module state as a plain JS prop if a reducer is provided 1`] = `
 <div>
   value

--- a/packages/holocron/__tests__/holocronModule.spec.jsx
+++ b/packages/holocron/__tests__/holocronModule.spec.jsx
@@ -509,6 +509,25 @@ describe('holocronModule', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should pass the moduleState to the module if options is passed without the `provideModuleState` key for backwards compatibility', () => {
+    const reducer = () => fromJS({ mockKey: 'mockValue' });
+    const Module = holocronModule({
+      name: 'mock-module',
+      reducer,
+      options: {
+        someOtherKey: 'someValue',
+      },
+    })(({ moduleState }) => <div>{JSON.stringify(moduleState)}|{typeof moduleState}</div>);
+    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } }));
+    const component = renderer.create(
+      <Provider store={mockStore}>
+        <Module />
+      </Provider>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should gracefully handle module state missing from store', () => {
     const reducer = () => fromJS({ x: 2 });
     const Module = holocronModule({

--- a/packages/holocron/__tests__/holocronModule.spec.jsx
+++ b/packages/holocron/__tests__/holocronModule.spec.jsx
@@ -56,7 +56,8 @@ describe('holocronModule', () => {
     fakeFetchClient = jest.fn();
     fakeGetState = jest.fn();
     fakeDispatch = jest.fn(
-      (func) => func(fakeDispatch, fakeGetState, { fetchClient: fakeFetchClient })
+      (func) => func(fakeDispatch, fakeGetState, { fetchClient: fakeFetchClient }
+      )
     );
     fakeSetState = jest.fn();
     fakeProps = {
@@ -72,7 +73,9 @@ describe('holocronModule', () => {
   afterEach(() => {
     global.BROWSER = false;
   });
-  const TestComponent = ({ moduleLoadStatus }) => <div>Mock Module - {moduleLoadStatus}</div>;
+  const TestComponent = ({ moduleLoadStatus }) => (
+    <div>Mock Module - {moduleLoadStatus}</div>
+  );
 
   describe('executeLoad', () => {
     it('should return undefined with no args', () => {
@@ -94,11 +97,9 @@ describe('holocronModule', () => {
   describe('executeLoadModuleData', () => {
     it('should call loadModuleData with correct args', async () => {
       expect.assertions(2);
-      await executeLoadModuleData(
-        fakeLoadModuleData,
-        FakeComponent,
-        { dispatch: fakeDispatch }
-      );
+      await executeLoadModuleData(fakeLoadModuleData, FakeComponent, {
+        dispatch: fakeDispatch,
+      });
       expect(fakeLoadModuleData.mock.calls).toMatchSnapshot();
       expect(fakeProps.dispatch).toHaveBeenCalled();
     });
@@ -174,7 +175,10 @@ describe('holocronModule', () => {
 
   it('should wrap module with no arguments', () => {
     const MyModuleComponent = holocronModule()(() => <div>Mock Module</div>);
-    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { key: 'value' } } }));
+    const mockStore = createStore(
+      (state) => state,
+      fromJS({ modules: { 'mock-module': { key: 'value' } } })
+    );
     const tree = renderer.create(<MyModuleComponent store={mockStore} />);
 
     expect(tree.toJSON()).toMatchSnapshot();
@@ -186,7 +190,10 @@ describe('holocronModule', () => {
       name: 'mock-module',
       reducer,
     })(({ moduleState }) => <div>{moduleState.key}</div>);
-    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { key: 'value' } } }));
+    const mockStore = createStore(
+      (state) => state,
+      fromJS({ modules: { 'mock-module': { key: 'value' } } })
+    );
     const component = renderer.create(<Module store={mockStore} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
@@ -195,7 +202,10 @@ describe('holocronModule', () => {
   it('should not rerender if module state has not changed', () => {
     const renderSpy = jest.fn();
     const moduleReducer = (state) => state || {};
-    const InnerModule = () => { renderSpy(); return <div>Mock Module</div>; };
+    const InnerModule = () => {
+      renderSpy();
+      return <div>Mock Module</div>;
+    };
     const Module = holocronModule({
       name: 'mock-module',
       reducer: moduleReducer,
@@ -209,14 +219,20 @@ describe('holocronModule', () => {
     });
     const mockStore = createStore(
       reducer,
-      fromJS({ app: { someParam: 'initial' }, modules: { 'mock-module': { key: 'value' } } })
+      fromJS({
+        app: { someParam: 'initial' },
+        modules: { 'mock-module': { key: 'value' } },
+      })
     );
     renderer.create(<Module store={mockStore} />);
-    mockStore.dispatch({ type: 'MOCK_ACTION_TYPE', newState: { someParam: 'new' } });
+    mockStore.dispatch({
+      type: 'MOCK_ACTION_TYPE',
+      newState: { someParam: 'new' },
+    });
     expect(renderSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should dispatch the module\'s load action on when component mount\'s with no preloaded state', () => {
+  it("should dispatch the module's load action on when component mount's with no preloaded state", () => {
     const load = jest.fn(() => () => Promise.resolve());
     const Module = holocronModule({
       name: 'mock-module',
@@ -232,18 +248,23 @@ describe('holocronModule', () => {
     // couldn't use toHaveBeenCalledWith because mapDispatchToProps is used
 
     const calledProps = load.mock.calls[0][0];
-    const calledPropsWithoutFunctions = _.pickBy(calledProps, (p) => typeof p !== 'function');
+    const calledPropsWithoutFunctions = _.pickBy(
+      calledProps,
+      (p) => typeof p !== 'function'
+    );
     expect(calledPropsWithoutFunctions).toEqual(props);
     expect(load).toHaveBeenCalledTimes(1);
   });
 
-  it('should dispatch the module\'s load action if it receives new props that pass shouldModuleReload', () => {
+  it("should dispatch the module's load action if it receives new props that pass shouldModuleReload", () => {
     const load = jest.fn(() => () => Promise.resolve());
-    const Module = connect((state) => state)(holocronModule({
-      name: 'mock-module',
-      load,
-      shouldModuleReload: (currProps, nextProps) => currProps.someParam !== nextProps.someParam,
-    })(() => <div>Mock Module</div>));
+    const Module = connect((state) => state)(
+      holocronModule({
+        name: 'mock-module',
+        load,
+        shouldModuleReload: (currProps, nextProps) => currProps.someParam !== nextProps.someParam,
+      })(() => <div>Mock Module</div>)
+    );
     const mockStore = createStore(
       (state, action) => (action.type === 'MOCK_ACTION_TYPE' ? action.newState : state),
       { someParam: 'initial' },
@@ -255,22 +276,33 @@ describe('holocronModule', () => {
       </Provider>
     );
     expect(load).toHaveBeenCalledTimes(1);
-    mockStore.dispatch({ type: 'MOCK_ACTION_TYPE', newState: { someParam: 'new' } });
+    mockStore.dispatch({
+      type: 'MOCK_ACTION_TYPE',
+      newState: { someParam: 'new' },
+    });
     // couldn't use toHaveBeenCalledWith because mapDispatchToProps is used
     const calledProps = load.mock.calls[1][0];
-    const calledPropsWithoutFunctions = _.pickBy(calledProps, (p) => typeof p !== 'function');
+    const calledPropsWithoutFunctions = _.pickBy(
+      calledProps,
+      (p) => typeof p !== 'function'
+    );
     expect(calledPropsWithoutFunctions).toEqual({ someParam: 'new' });
     expect(load).toHaveBeenCalledTimes(2);
   });
 
-  it('should not dispatch the module\'s load action if it receives new props that do not pass shouldModuleReload', () => {
+  it("should not dispatch the module's load action if it receives new props that do not pass shouldModuleReload", () => {
     const load = jest.fn(() => ({ type: 'LOAD' }));
-    const Module = connect((state) => state)(holocronModule({
-      name: 'mock-module',
-      load,
-      shouldModuleReload: (currProps, nextProps) => currProps.someParam !== nextProps.someParam,
-    })(() => <div>Mock Module</div>));
-    const mockStore = createStore((state, action) => (action.type === 'MOCK_ACTION_TYPE' ? action.newState : state), { someParam: 'initial' });
+    const Module = connect((state) => state)(
+      holocronModule({
+        name: 'mock-module',
+        load,
+        shouldModuleReload: (currProps, nextProps) => currProps.someParam !== nextProps.someParam,
+      })(() => <div>Mock Module</div>)
+    );
+    const mockStore = createStore(
+      (state, action) => (action.type === 'MOCK_ACTION_TYPE' ? action.newState : state),
+      { someParam: 'initial' }
+    );
     mount(
       <Provider store={mockStore}>
         <Module />
@@ -278,17 +310,25 @@ describe('holocronModule', () => {
     );
     expect(load).toHaveBeenCalledTimes(1);
     const { dispatch } = mockStore;
-    dispatch({ type: 'MOCK_ACTION_TYPE', newState: { someParam: 'initial', differentParam: 'new' } });
+    dispatch({
+      type: 'MOCK_ACTION_TYPE',
+      newState: { someParam: 'initial', differentParam: 'new' },
+    });
     expect(load).toHaveBeenCalledTimes(1);
   });
 
-  it('should not dispatch the module\'s load action if no shouldModuleReload function is provided', () => {
+  it("should not dispatch the module's load action if no shouldModuleReload function is provided", () => {
     const load = jest.fn(() => ({ type: 'LOAD' }));
-    const Module = connect((state) => state)(holocronModule({
-      name: 'mock-module',
-      load,
-    })(() => <div>Mock Module</div>));
-    const mockStore = createStore((state, action) => (action.type === 'MOCK_ACTION_TYPE' ? action.newState : state), { someParam: 'initial' });
+    const Module = connect((state) => state)(
+      holocronModule({
+        name: 'mock-module',
+        load,
+      })(() => <div>Mock Module</div>)
+    );
+    const mockStore = createStore(
+      (state, action) => (action.type === 'MOCK_ACTION_TYPE' ? action.newState : state),
+      { someParam: 'initial' }
+    );
     mount(
       <Provider store={mockStore}>
         <Module />
@@ -315,7 +355,9 @@ describe('holocronModule', () => {
       </Provider>
     );
 
-    expect(wrapper.find(TestComponent).prop('moduleLoadStatus')).toEqual('loading');
+    expect(wrapper.find(TestComponent).prop('moduleLoadStatus')).toEqual(
+      'loading'
+    );
   });
 
   it('should pass the moduleLoadStatus prop as loaded when loaded', async () => {
@@ -326,7 +368,8 @@ describe('holocronModule', () => {
       load,
     })(TestComponent);
     const mockStore = createStore(
-      (state) => state, applyMiddleware(thunk.withExtraArgument({ fetchClient: jest.fn() }))
+      (state) => state,
+      applyMiddleware(thunk.withExtraArgument({ fetchClient: jest.fn() }))
     );
 
     const wrapper = mount(
@@ -339,7 +382,9 @@ describe('holocronModule', () => {
     await sleep(1);
 
     wrapper.update();
-    expect(wrapper.find(TestComponent).prop('moduleLoadStatus')).toEqual('loaded');
+    expect(wrapper.find(TestComponent).prop('moduleLoadStatus')).toEqual(
+      'loaded'
+    );
   });
 
   it('should pass the moduleLoadStatus prop as error when it failed to load', async () => {
@@ -358,7 +403,9 @@ describe('holocronModule', () => {
     );
     await sleep(1);
     wrapper.update();
-    expect(wrapper.find(TestComponent).prop('moduleLoadStatus')).toEqual('error');
+    expect(wrapper.find(TestComponent).prop('moduleLoadStatus')).toEqual(
+      'error'
+    );
     wrapper.unmount();
   });
 
@@ -385,10 +432,18 @@ describe('holocronModule', () => {
     const name = 'mock-module';
     const SomeComponent = () => <div />;
     SomeComponent.displayName = 'DisplayName';
-    function FuncName() { return <div />; }
-    expect(holocronModule({ name })(SomeComponent).displayName).toBe('Connect(HolocronModule(DisplayName))');
-    expect(holocronModule({ name })(FuncName).displayName).toBe('Connect(HolocronModule(FuncName))');
-    expect(holocronModule({ name })(() => <div />).displayName).toBe('Connect(HolocronModule(mock-module))');
+    function FuncName() {
+      return <div />;
+    }
+    expect(holocronModule({ name })(SomeComponent).displayName).toBe(
+      'Connect(HolocronModule(DisplayName))'
+    );
+    expect(holocronModule({ name })(FuncName).displayName).toBe(
+      'Connect(HolocronModule(FuncName))'
+    );
+    expect(holocronModule({ name })(() => <div />).displayName).toBe(
+      'Connect(HolocronModule(mock-module))'
+    );
   });
 
   it('should attach the load function as a static if it is on the browser', () => {
@@ -463,8 +518,15 @@ describe('holocronModule', () => {
       name: 'mock-module',
       reducer,
       mergeProps,
-    })(({ moduleState: { x }, y, xy }) => <div>{x} * {y} = {xy}</div>);
-    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { x: 3 } } }));
+    })(({ moduleState: { x }, y, xy }) => (
+      <div>
+        {x} * {y} = {xy}
+      </div>
+    ));
+    const mockStore = createStore(
+      (state) => state,
+      fromJS({ modules: { 'mock-module': { x: 3 } } })
+    );
     const component = renderer.create(
       <Provider store={mockStore}>
         <Module y={4} />
@@ -479,15 +541,28 @@ describe('holocronModule', () => {
     const Module = holocronModule({
       name: 'mock-module',
       reducer,
-    })(({ moduleState }) => <div>{JSON.stringify(moduleState)}|{typeof moduleState}</div>);
-    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } }));
+    })(({ moduleState }) => (
+      <div>
+        {JSON.stringify(moduleState)}|{typeof moduleState}
+      </div>
+    ));
+    const mockStore = createStore(
+      (state) => state,
+      fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } })
+    );
     const component = renderer.create(
       <Provider store={mockStore}>
         <Module />
       </Provider>
     );
     const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(tree).toMatchInlineSnapshot(`
+      <div>
+        {"mockKey":"mockValue"}
+        |
+        object
+      </div>
+    `);
   });
 
   it('should not pass the moduleState to the module if options.provideModuleState is passed as false', () => {
@@ -498,15 +573,27 @@ describe('holocronModule', () => {
       options: {
         provideModuleState: false,
       },
-    })(({ moduleState }) => <div>{JSON.stringify(moduleState)}|{typeof moduleState}</div>);
-    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } }));
+    })(({ moduleState }) => (
+      <div>
+        {JSON.stringify(moduleState)}|{typeof moduleState}
+      </div>
+    ));
+    const mockStore = createStore(
+      (state) => state,
+      fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } })
+    );
     const component = renderer.create(
       <Provider store={mockStore}>
         <Module />
       </Provider>
     );
     const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(tree).toMatchInlineSnapshot(`
+      <div>
+        |
+        undefined
+      </div>
+    `);
   });
 
   it('should pass the moduleState to the module if options is passed without the `provideModuleState` key for backwards compatibility', () => {
@@ -517,15 +604,28 @@ describe('holocronModule', () => {
       options: {
         someOtherKey: 'someValue',
       },
-    })(({ moduleState }) => <div>{JSON.stringify(moduleState)}|{typeof moduleState}</div>);
-    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } }));
+    })(({ moduleState }) => (
+      <div>
+        {JSON.stringify(moduleState)}|{typeof moduleState}
+      </div>
+    ));
+    const mockStore = createStore(
+      (state) => state,
+      fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } })
+    );
     const component = renderer.create(
       <Provider store={mockStore}>
         <Module />
       </Provider>
     );
     const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+    expect(tree).toMatchInlineSnapshot(`
+      <div>
+        {"mockKey":"mockValue"}
+        |
+        object
+      </div>
+    `);
   });
 
   it('should gracefully handle module state missing from store', () => {

--- a/packages/holocron/__tests__/holocronModule.spec.jsx
+++ b/packages/holocron/__tests__/holocronModule.spec.jsx
@@ -474,6 +474,41 @@ describe('holocronModule', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should pass the moduleState to the module by default, if a reducer and name are specified', () => {
+    const reducer = () => fromJS({ mockKey: 'mockValue' });
+    const Module = holocronModule({
+      name: 'mock-module',
+      reducer,
+    })(({ moduleState }) => <div>{JSON.stringify(moduleState)}|{typeof moduleState}</div>);
+    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } }));
+    const component = renderer.create(
+      <Provider store={mockStore}>
+        <Module />
+      </Provider>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should not pass the moduleState to the module if options.provideModuleState is passed as false', () => {
+    const reducer = () => fromJS({ mockKey: 'mockValue' });
+    const Module = holocronModule({
+      name: 'mock-module',
+      reducer,
+      options: {
+        provideModuleState: false,
+      },
+    })(({ moduleState }) => <div>{JSON.stringify(moduleState)}|{typeof moduleState}</div>);
+    const mockStore = createStore((state) => state, fromJS({ modules: { 'mock-module': { mockKey: 'mockValue' } } }));
+    const component = renderer.create(
+      <Provider store={mockStore}>
+        <Module />
+      </Provider>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should gracefully handle module state missing from store', () => {
     const reducer = () => fromJS({ x: 2 });
     const Module = holocronModule({

--- a/packages/holocron/docs/api/README.md
+++ b/packages/holocron/docs/api/README.md
@@ -90,15 +90,22 @@ The optional `holocron` object set to the parent React Component inside a Holocr
 
 ##### Properties
 
-| name | type | required | value |
-|---|---|---|---|
-| `name` | `String` | `true` | The name of your Holocron module |
-| `reducer` | `(state, action) => newState` | `false` | The Redux reducer to register when your module is loaded. *Requires a `name`* |
-| `loadModuleData` | `({ store, fetchClient, ownProps, module }) => Promise` | `false` | A function that fetches data required by your module |
-| `shouldModuleReload` | `(oldProps, newProps) => Boolean` | `false` | A function to determine if your `loadModuleData` and or `load` function should be called again |
-| `mergeProps` | `(stateProps, dispatchProps, ownProps) => Object` | `false` | Passed down to Redux connect |
-| `options` | `Object` | `false` | Additional options |
-| `load` *☠️ Deprecated* | `(props) => Promise` or `(props) => (dispatch, getState, ...extra) => Promise` | `false` | A deprecated function that fetches data required by your module. Please use `loadModuleData` instead.
+| name                   | type                                                                           | required | value                                                                                                 |
+|------------------------|--------------------------------------------------------------------------------|----------|-------------------------------------------------------------------------------------------------------|
+| `name`                 | `String`                                                                       | `true`   | The name of your Holocron module                                                                      |
+| `reducer`              | `(state, action) => newState`                                                  | `false`  | The Redux reducer to register when your module is loaded. *Requires a `name`*                         |
+| `loadModuleData`       | `({ store, fetchClient, ownProps, module }) => Promise`                        | `false`  | A function that fetches data required by your module                                                  |
+| `shouldModuleReload`   | `(oldProps, newProps) => Boolean`                                              | `false`  | A function to determine if your `loadModuleData` and or `load` function should be called again        |
+| `mergeProps`           | `(stateProps, dispatchProps, ownProps) => Object`                              | `false`  | Passed down to Redux connect                                                                          |
+| `options`              | `Object`                                                                       | `false`  | Additional options, see below                                                                         |
+| `load` *☠️ Deprecated* | `(props) => Promise` or `(props) => (dispatch, getState, ...extra) => Promise` | `false`  | A deprecated function that fetches data required by your module. Please use `loadModuleData` instead. |
+
+###### options object
+
+| name                   | type       | default | required | value                                                                                                                                |
+|------------------------|------------|---------|----------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `ssr` *☠️ Deprecated*  | `Boolean`  | falsy   | `false`  | enable the (deprecated) load function to be called on the server                                                                     |
+| `provideModuleState`   | `Boolean`  | truthy  | `false`  | if specified as `false` the module will not be passed `moduleState` as a prop. This will be the default to falsy in future versions. |
 
 #### Usage
 

--- a/packages/holocron/src/holocronModule.jsx
+++ b/packages/holocron/src/holocronModule.jsx
@@ -94,7 +94,7 @@ export default function holocronModule({
   shouldModuleReload,
   loadModuleData,
   mergeProps,
-  options = { provideModuleState: true },
+  options = { },
 } = {}) {
   return function wrapWithHolocron(WrappedComponent) {
     const HolocronModuleWrapper = (props) => {
@@ -160,8 +160,8 @@ export default function holocronModule({
 
     if (reducer && name) {
       HolocronModuleWrapper[REDUCER_KEY] = reducer;
-      // TODO: make this default as a breaking performance feature in the next major version
-      if (options.provideModuleState) {
+      // TODO: make this off default as a breaking performance feature in the next major version
+      if (!('provideModuleState' in options) || options.provideModuleState !== false) {
         const getModuleState = createSelector(
           (state) => state.getIn(
             [MODULES_STORE_KEY, name],

--- a/packages/holocron/src/holocronModule.jsx
+++ b/packages/holocron/src/holocronModule.jsx
@@ -94,7 +94,7 @@ export default function holocronModule({
   shouldModuleReload,
   loadModuleData,
   mergeProps,
-  options = {},
+  options = { provideModuleState: true },
 } = {}) {
   return function wrapWithHolocron(WrappedComponent) {
     const HolocronModuleWrapper = (props) => {
@@ -160,18 +160,21 @@ export default function holocronModule({
 
     if (reducer && name) {
       HolocronModuleWrapper[REDUCER_KEY] = reducer;
-      const getModuleState = createSelector(
-        (state) => state.getIn(
-          [MODULES_STORE_KEY, name],
-          reducer(undefined, { type: INIT_MODULE_STATE })
-        ),
-        (moduleState) => moduleState.toJS()
-      );
+      // TODO: make this default as a breaking performance feature in the next major version
+      if (options.provideModuleState) {
+        const getModuleState = createSelector(
+          (state) => state.getIn(
+            [MODULES_STORE_KEY, name],
+            reducer(undefined, { type: INIT_MODULE_STATE })
+          ),
+          (moduleState) => moduleState.toJS()
+        );
 
-      mapModuleStateToProps = ((state) => {
-        const moduleState = getModuleState(state);
-        return { moduleState };
-      });
+        mapModuleStateToProps = ((state) => {
+          const moduleState = getModuleState(state);
+          return { moduleState };
+        });
+      }
     }
 
     const mapDispatchToProps = (dispatch) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8909,6 +8909,11 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
+
 pretty-format@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"


### PR DESCRIPTION
## Motivation and Context
This can prevent unnecessary 'toJS()' calls and re-renders which is a major performance point for large applications

## How Has This Been Tested?
unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
N/A
