### PR TITLE
feat(compose): add console error

### DIFF
--- a/packages/holocron/__tests__/ducks/compose.spec.js
+++ b/packages/holocron/__tests__/ducks/compose.spec.js
@@ -16,6 +16,8 @@ import { LOAD_KEY } from '../../src/ducks/constants';
 
 import { composeModules } from '../../src/ducks/compose';
 
+const consoleError = jest.spyOn(console, 'error');
+
 jest.mock('../../src/ducks/load', () => ({
   loadModule: jest.fn(() => Promise.resolve({})),
 }));
@@ -68,6 +70,11 @@ describe('composeModules', () => {
     return thunk(dispatch)
       .then(([error]) => {
         expect(error).toBe(moduleLoadError);
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        expect(consoleError).toHaveBeenCalledWith(
+          'Error while attempting to call \'load\' or \'loadModuleData\' inside composeModules for my-submodule.',
+          error
+        );
       });
   });
 
@@ -114,6 +121,11 @@ describe('composeModules', () => {
     return thunk(dispatch, getState, { fetchClient })
       .catch((err) => {
         expect(err).toBe(error);
+        expect(consoleError).toHaveBeenCalledTimes(1);
+        expect(consoleError).toHaveBeenCalledWith(
+          'Error while attempting to call \'load\' or \'loadModuleData\' inside composeModules for my-submodule.',
+          error
+        );
         resolveOtherPromise();
       });
   });

--- a/packages/holocron/src/ducks/compose.js
+++ b/packages/holocron/src/ducks/compose.js
@@ -53,6 +53,7 @@ export function composeModules(moduleConfigs) {
           return Promise.resolve();
         })
         .catch((error) => {
+          console.error(`Error while attempting to call 'load' or 'loadModuleData' inside composeModules for ${name}.`, error);
           if (error.abortComposeModules) throw error;
           return error;
         });


### PR DESCRIPTION
Adding console.error for matching visibility as given by holocronModule.

## Description
Adding this console.error will help add visibility to errors coming out of `loadModuleData` when performed by `composeModules`. This will help debugging overall.

## Motivation and Context
The error is captured and returned, but otherwise is treated silently. With the console.error I can see this occur on both server and client.

## How Has This Been Tested?
Unit tested only.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
None.
