### PR TITLE
fix(RenderModule): check module loaded state before rendering

### DIFF
--- a/packages/holocron/__tests__/RenderModule.spec.jsx
+++ b/packages/holocron/__tests__/RenderModule.spec.jsx
@@ -31,6 +31,13 @@ const store = {
   modules: fromJS({
     'my-test-module': MyTestModule,
   }),
+  getState: jest.fn(() => fromJS({
+    holocron: {
+      loaded: {
+        'my-test-module': true,
+      },
+    },
+  })),
 };
 
 describe('RenderModule', () => {
@@ -38,25 +45,32 @@ describe('RenderModule', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
-  it('should warn when it cannot find a module', () => {
-    expect.assertions(1);
-
-    mount(
-      <ReactReduxContext.Provider value={{ store }}>
-        <RenderModule moduleName="not-in-module-map" />
-      </ReactReduxContext.Provider>
-    );
-    expect(consoleWarn.mock.calls).toMatchSnapshot();
-  });
-
-  it('should render null when it cannot find a module', () => {
-    expect.assertions(1);
+  it('should warn and render null when it cannot find a module in registry', () => {
+    expect.assertions(2);
 
     const tree = mount(
       <ReactReduxContext.Provider value={{ store }}>
         <RenderModule moduleName="not-in-module-map" />
       </ReactReduxContext.Provider>
     );
+    expect(consoleWarn.mock.calls).toMatchSnapshot();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should warn and render null when module is not loaded', () => {
+    store.getState.mockImplementationOnce(() => fromJS({
+      holocron: {
+        loaded: {},
+      },
+    }));
+    expect.assertions(2);
+
+    const tree = mount(
+      <ReactReduxContext.Provider value={{ store }}>
+        <RenderModule moduleName="not-in-module-map" />
+      </ReactReduxContext.Provider>
+    );
+    expect(consoleWarn.mock.calls).toMatchSnapshot();
     expect(tree).toMatchSnapshot();
   });
 

--- a/packages/holocron/__tests__/__snapshots__/RenderModule.spec.jsx.snap
+++ b/packages/holocron/__tests__/__snapshots__/RenderModule.spec.jsx.snap
@@ -53,17 +53,32 @@ exports[`RenderModule should render a module 1`] = `
 </RenderModule>
 `;
 
-exports[`RenderModule should render null when it cannot find a module 1`] = `
+exports[`RenderModule should warn and render null when it cannot find a module in registry 1`] = `
+Array [
+  Array [
+    "Module not-in-module-map was not found in the holocron module registry",
+  ],
+]
+`;
+
+exports[`RenderModule should warn and render null when it cannot find a module in registry 2`] = `
 <RenderModule
   moduleName="not-in-module-map"
   props={Object {}}
 />
 `;
 
-exports[`RenderModule should warn when it cannot find a module 1`] = `
+exports[`RenderModule should warn and render null when module is not loaded 1`] = `
 Array [
   Array [
     "Module not-in-module-map was not found in the holocron module registry",
   ],
 ]
+`;
+
+exports[`RenderModule should warn and render null when module is not loaded 2`] = `
+<RenderModule
+  moduleName="not-in-module-map"
+  props={Object {}}
+/>
 `;

--- a/packages/holocron/src/RenderModule.jsx
+++ b/packages/holocron/src/RenderModule.jsx
@@ -16,13 +16,15 @@ import React from 'react';
 import { ReactReduxContext } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import { isLoaded } from './ducks/load';
 import { getModule } from './moduleRegistry';
 
 export default function RenderModule({ children, moduleName, props }) {
   const { store } = React.useContext(ReactReduxContext);
 
   const Module = getModule(moduleName, store.modules);
-  if (!Module) {
+  const isModuleLoaded = isLoaded(moduleName)(store.getState());
+  if (!Module || !isModuleLoaded) {
     console.warn(`Module ${moduleName} was not found in the holocron module registry`);
     return null;
   }


### PR DESCRIPTION
Solves the issue where a module can be rendered before it's reducer is registered.

## Description
When a module is loading it is first entered into into the module registry but it may not be finished registering it's reducer. RenderModule only checks against it being in the registry, but not the state that confirms the reducer has been registered. This adds that check so that a module cannot be rendered before it is fully loaded.

## Motivation and Context
Errors can occasionally occur using `composeModules` and `RenderModule` where it may attempt to render the module before it's fully loaded. This PR is meant to prevent those issues from happening.

## How Has This Been Tested?
First, it was unit tested.
Second, I packed the lib and installed it onto one-app on local. Using this I was able to reproduce the scenario I had that triggered this issue and saw that it correctly went into the early return when the module `loaded` state wasn't present.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
None, this fix will work without any manual intervention.
