### PR TITLE
chore(workflows): use GITHUB_OUTPUT instead of ::set-output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - id: commit
-      run: echo "::set-output name=message::${{ github.event.head_commit.message }}"
+      run: echo "message=${{ github.event.head_commit.message }}" >> $GITHUB_OUTPUT
     outputs:
       commitMsg: ${{ steps.commit.outputs.message }}
   publish:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
replace
```shell
echo "::set-output name={name}::{value}"
```
with
```shell
echo "{name}={value}" >> $GITHUB_OUTPUT
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
these are now showing as warnings in the runs, e.g. https://github.com/americanexpress/one-app/actions/runs/6344142425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
https://github.com/americanexpress/one-app/pull/1141#issuecomment-1740101159

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for Holocron users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Holocron?
<!--- Please describe how your changes impacts developers using Holocron. -->
None