### PR TITLE
feat(promiseStore): promiseStore

### DIFF
--- a/packages/holocron/src/createHolocronStore.js
+++ b/packages/holocron/src/createHolocronStore.js
@@ -22,6 +22,7 @@ import { getModule, getModules } from './moduleRegistry';
 import {
   HOLOCRON_STORE_KEY, MODULES_STORE_KEY, REDUCER_KEY, MODULE_REDUCER_ADDED,
 } from './ducks/constants';
+import PromiseStore from './promiseStore';
 
 function immutableCombineReducersWithNewModules(moduleReducerMap, newModuleState) {
   if (Object.keys(moduleReducerMap).length === 0) {
@@ -116,10 +117,14 @@ const holocronEnhancer = (localsForBuildInitialState, extraThunkArguments = {}) 
     getState: store.getState,
     dispatch: (action) => dispatch(action),
   };
+
+  const promiseStore = new PromiseStore();
+
   dispatch = thunk.withExtraArgument({
     ...extraThunkArguments,
     rebuildReducer,
     modules: store.modules,
+    promiseStore,
   })(middlewareAPI)(store.dispatch);
 
   return {

--- a/packages/holocron/src/index.js
+++ b/packages/holocron/src/index.js
@@ -43,6 +43,12 @@ import {
   setRequiredExternalsRegistry,
 } from './externalRegistry';
 
+import {
+  getStoredPromise,
+  storePromise,
+  useStoredPromise,
+} from './promiseStore';
+
 // Public API
 export {
   createHolocronStore,
@@ -69,4 +75,7 @@ export {
   setRequiredExternalsRegistry,
   clearModulesUsingExternals,
   getModulesUsingExternals,
+  getStoredPromise,
+  storePromise,
+  useStoredPromise,
 };

--- a/packages/holocron/src/promiseStore.jsx
+++ b/packages/holocron/src/promiseStore.jsx
@@ -9,9 +9,7 @@ import { useDispatch } from 'react-redux';
  *   instead dispatching the below thunks, or using the provided hooks
  */
 class PromiseStore {
-  constructor() {
-    this.promises = {};
-  }
+  #promises = new Map();
 
   /**
    * @param {string} domain The domain of the promise, should be the module name
@@ -21,10 +19,10 @@ class PromiseStore {
    * @returns {void}
    */
   store = (domain, key, promise) => {
-    if (!this.promises[domain]) {
-      this.promises[domain] = {};
+    if (!this.#promises[domain]) {
+      this.#promises[domain] = new Map();
     }
-    this.promises[domain][key] = promise;
+    this.#promises[domain][key] = promise;
   };
 
   /**
@@ -33,7 +31,7 @@ class PromiseStore {
    * @param {string} key The key of the promise
    * @returns {Promise<any> | undefined}
    */
-  get = (domain, key) => this.promises?.[domain]?.[key];
+  get = (domain, key) => this.#promises?.[domain]?.[key];
 }
 
 export default PromiseStore;

--- a/packages/holocron/src/promiseStore.jsx
+++ b/packages/holocron/src/promiseStore.jsx
@@ -1,0 +1,87 @@
+import { useDispatch } from 'react-redux';
+
+/** @typedef {import('redux-thunk').ThunkAction} ThunkAction */
+
+/**
+ * A class to store promises by domain and key
+ *
+ * In general, Module code should not interact with the promise store directly,
+ *   instead dispatching the below thunks, or using the provided hooks
+ */
+class PromiseStore {
+  constructor() {
+    this.promises = {};
+  }
+
+  /**
+   * @param {string} domain The domain of the promise, should be the module name
+   *   if being stored by a module, or the package name if being stored by a package
+   * @param {string} key The key of the promise, it is up to the caller to manage key duplication
+   * @param {Promise<any>} promise The promise to be stored
+   * @returns {void}
+   */
+  store = (domain, key, promise) => {
+    if (!this.promises[domain]) {
+      this.promises[domain] = {};
+    }
+    this.promises[domain][key] = promise;
+  };
+
+  /**
+   * @param {string} domain The domain of the promise, should be the module name
+   *   if being stored by a module, or the package name if being stored by a package
+   * @param {string} key The key of the promise
+   * @returns {Promise<any> | undefined}
+   */
+  get = (domain, key) => this.promises?.[domain]?.[key];
+}
+
+export default PromiseStore;
+
+// Thunk based access and storage
+// the (_, __, { promiseStore }) pattern is to skip the first two arguments of thunks
+
+/**
+ * @param {string} domain The domain of the promise, should be the module name
+ *   if being stored by a module, or the package name if being stored by a package
+ * @param {string} key The key of the promise
+ * @returns {ThunkAction<Promise<any> | undefined>}
+ *
+ * usage: `const promise = dispatch(getStoredPromise('domain', 'key'))`
+ */
+// eslint-disable-next-line arrow-body-style -- else triggers max-length
+export const getStoredPromise = (domain, key) => {
+  return (_, __, { promiseStore }) => promiseStore.get(domain, key);
+};
+
+/**
+ * @param {string} domain The domain of the promise, should be the module name
+ *  if being stored by a module, or the package name if being stored by a package
+ * @param {string} key The key of the promise, it is up to the caller to manage key duplication
+ * @param {Promise<any>} promise The promise to be stored
+ * @returns {ThunkAction<void>}
+ *
+ * usage: `dispatch(storePromise('domain', 'key', fetch('some.url.com')))`
+ */
+// eslint-disable-next-line arrow-body-style -- else triggers max-length
+export const storePromise = (domain, key, promise) => {
+  return (_, __, { promiseStore }) => promiseStore.store(domain, key, promise);
+};
+
+// Hook based access
+
+// Note: No hook based `storePromise` because promises should only be
+// stored during the data phase, not the render phase
+
+/**
+ * @param {string} domain The domain of the promise, should be the module name
+ *  if being stored by a module, or the package name if being stored by a package
+ * @param {string} key The key of the promise, it is up to the caller to manage key duplication
+ * @returns {Promise<any> | undefined}
+ *
+ * usage: `const promise = useStoredPromise('domain', 'key')`
+ */
+export const useStoredPromise = (domain, key) => {
+  const dispatch = useDispatch();
+  return dispatch(getStoredPromise(domain, key));
+};


### PR DESCRIPTION
# :bulb: Feature request: Holocron `PromiseStore`

Holocron comes with a sophistocated `DataStore`, The `DataStore` is pluggable, shared across the entire system, and scoped to each request in the server.

At a high level, the `DataStore` is used by:
 * `holocron` itself as a `ModuleStatusStore`
 * `modules` as a `ModuleStore`
 * `fetchye` and `iguazu` as a `CacheStore` (although technically these stores are registered by the root module)
 * One App as a `ConfigStore`, an `IntlStore`, a `RedirectionStore`, and a `RenderingStore`. This looks a little like this: (organised by domain and type, not structure)

```mermaid
graph TD;
    DataStore-->holocron;
    holocron-->ModuleStatusStore;
    DataStore-->root-module;
    root-module-->ModuleStore;
    ModuleStore-->fetchye;
    ModuleStore-->iguazu;
    fetchye-->CacheStore;
    iguazu-->CacheStore;
    DataStore-->child-module-1;
    child-module-1-->ModuleStore;
    DataStore-->child-module-2;
    child-module-2-->ModuleStore;
    DataStore-->OneApp;
    OneApp-->ConfigStore;
    OneApp-->IntlStore;
    OneApp-->RedirectionStore;
    OneApp-->RenderingStore;
```

This system has allowed Holocron, One App, fetchye etc. To solve many problems when it comes to Two Phase SSR, Client Hydration, Api De-duplication... The list goes on.

However, there is an underlying technology that prevents this versatile store being used for Promise's: transmitJS

The DataStore is serialised and sent to the client, where it is deserialised. Promises cannot be meaningfully serialised, so cannot be put in the `DataStore`.

## So why do we need a Promise Store?

A `PromiseStore` would serve the same purpose as the `DataStore`, but for promises: To share promises across the system, scoped to the individual request, and even send those promises to the client.

In the immediacy, the promise store would serve as a solution to this bug in fetchye: https://github.com/americanexpress/fetchye/issues/93, which requires _Promises_ be shared across the module boundary.

Additionally, The up coming React Streaming feature in One App requires not only to share promises between modules, but then to be able to send these promises to the client, and hydrate them in such a way they can then be resolved at a later date. ( I mentioned above that Promises cannot be serialised, and this is true, but React Streaming contains a way of passing data from the server to the client, the resolving the client promises with that data, which makes it _look_ like the promise was resolved across the server/client boundary, this would be integrated with the PromiseStore if streaming is enabled ).

Since it is Holocron's responsibility to configure, maintain, serialize, and hydrate the `DataStore`. I beleive it should also be Holocrons reponsibility to do the same with a hypothetical `PromiseStore`

## So how would this work.

In short, a new object will be attached to `extraThunkArguments`, that serves as a promise store. 

New Thunks and Hooks will be added for accessing the promised from this object, in an abstract enough way that we can change the underlying fabric of the PromiseStore freely in the future.

This PR serves as a reference implementation of whats needed, Now is a good time to jump to the diff, have a read of the code, then come back up here and read my predicted Questions and Answers.

Note: This is not a final implementation. It explicitly lacks unit tests to keep the diff focussed, and may need tweaks when integrating this change into One App and fetchye.

## Some questions you might have while reading the PR:

### How would Fetchye use this?

The [`makeServerFetchye` function](https://github.com/americanexpress/fetchye/blob/main/packages/fetchye/src/makeServerFetchye.js) would be extended to be optionally passed a PromiseStore (any object with a `storePromise` and `getPromise` function on it, non-one-app users can bring their own, as they do the cache).

in `makeOneServerFetchye`, it would pass the `PromiseStore` from holocron into `makeServerFetchye`.

If there _is_ a `PromiseStore` passed into `makeServerFetchye` it will first check for the existence of a promise in the store for the computed cache key. If it exists, it would `await` it, then return the `coerced` fields like normal.

This would mean that the second call to the same data would 'inherit' the promise from the first, and act correctly.

### Why attach the `PromiseStore` to the `extraThunkArgs`?

* Its an existing solution for sharing something 'System Wide'
  - Although not currently used for a whole lot, the `extraThunkArgs` is Holocron's way of sharing "things" system wide, such as the `fetchClient` and the `rebuildReducer` function. We rarely expect our consumers (Module Code Authors) to interact with these `extraThunkArgs`, instead it serves as an internal transport for "things" that we need anywhere.
* Its scoped to the request
  - This means our promises are scoped to a single request in the server for free.

### Why no Hook for storing a promise

This `PromiseStore` is currently focussed on solving two problems. One Now (the fetchye bug) and one in the future (React Streaming)

Neither of these require the ability to store a promise at request time. But always want to store promises at 'LoadModuleData' time.

### Any more questions?

Just ask in a comment :)


## Alternatives Considered

Both the fetchye bug, and the Streaming system have considered alternatives to this solution, and infact streaming is working partially without this feature. However both cannot overcome all issues they face without _some_ iteration of a 'System Wide' `PromiseStore`

### Don't attach to `extraThunkArgs`

I considered this at length, however ultimately to satisfy both `System Wide` and `Scoped to a Single Request`, we would simply need to re-engineer the `dispatch` system and attach the `PromiseStore` to _that_. Which adds needless complexity.

### Just actually store the Promises in the Redux Store, and handle the serialisation separately.

This was considered (and actually implemented for streaming), however its quite messy, and leaves us with far more code to maintain than the above does.

Futhermore, the Holocron `DataStore` is `immutable` and Promises are _not_ an immutable data type, therefore Promises don't belong in the DataStore for more than one reason.